### PR TITLE
plus2papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Welcome to open an issue or make a pull request!
 + Zero-Shot Recommendations with Pre-Trained Large Language Models for Multimodal Nudging, arxiv 2023, [[paper]](https://arxiv.org/abs/2309.01026).
 + Prompt Distillation for Efficient LLM-based Recommendation, CIKM 2023, [[paper]](https://lileipisces.github.io/files/CIKM23-POD-paper.pdf), [[code]](https://github.com/lileipisces/POD).
 + Large Language Models as Zero-Shot Conversational Recommenders, CIKM 2023, [[paper]](https://arxiv.org/abs/2308.10053), [[code]](https://github.com/AaronHeee/LLMs-as-Zero-Shot-Conversational-RecSys).
++ Leveraging Large Language Models (LLMs) to Empower Training-Free Dataset Condensation for Content-Based Recommendation, arxiv 2023, [[paper]](https://arxiv.org/pdf/2310.09874.pdf).
++ On Generative Agents in Recommendation, arxiv 2023, [[paper]](https://arxiv.org/pdf/2310.10108.pdf), [[code]](https://github.com/LehengTHU/Agent4Rec).
+
 
 ### Survey
 + A Survey on Large Language Models for Recommendation, arxiv 2023, [[paper]](https://arxiv.org/abs/2305.19860).
@@ -74,3 +77,4 @@ Welcome to open an issue or make a pull request!
 ## Dataset
 + Amazon-M2: A Multilingual Multi-locale Shopping Session Dataset for Recommendation and Text Generation, arvix 2023, [[paper]](https://arxiv.org/abs/2307.09688), [[KDD Cup 2023]](https://kddcup23.github.io/).
 + PixelRec: An Image Dataset for Benchmarking Recommender Systems with Raw Pixels, arvix 2023, [[paper]](https://arxiv.org/abs/2309.06789), [[link]](https://github.com/westlake-repl/PixelRec).
+


### PR DESCRIPTION
Two recent arxiv papers are added to the paper list:
(1) Leveraging Large Language Models (LLMs) to Empower Training-Free Dataset Condensation for Content-Based Recommendation
(2) On Generative Agents in Recommendation, arxiv 2023